### PR TITLE
Optimization: release flags

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -45,6 +45,7 @@ jobs:
           source $HOME/.cargo/env
           rustup target add ${{ matrix.target }}
           cargo build --release --target ${{ matrix.target }}
+          strip target/${{ matrix.target }}/release/backend-rust
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "backend-rust"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
+[profile.release]
+target-cpu = "native"
+opt-level = 3
+lto = true
+codegen-units = 1
 # cargo flamegraph
-#[profile.release]
 #debug = true
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,9 @@ name = "backend-rust"
 version = "0.6.0"
 edition = "2021"
 
+# export RUSTFLAGS="-C target-cpu=native"
+# cargo build --release
 [profile.release]
-target-cpu = "native"
 opt-level = 3
 lto = true
 codegen-units = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use p256::{elliptic_curve::sec1::ToEncodedPoint, PublicKey, SecretKey};
 use p256::ecdh::EphemeralSecret;
 use rand_core::{OsRng, RngCore};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 use tokio::net::TcpListener;
 use tokio_native_tls::TlsAcceptor;
 use tokio_tungstenite::accept_async;
@@ -478,15 +478,7 @@ fn custom_ecdh(
     // Extract the x-coordinate as the shared secret
     let x_coordinate = shared_point.x();
     let shared_secret = x_coordinate.to_vec();
-
     // println!("Raw shared secret: {}", hex::encode(&shared_secret));
-
-    // Hash the x-coordinate using SHA-256
-    let mut hasher = Sha256::new();
-    hasher.update(x_coordinate);
-    // let hashed_secret = hasher.finalize().to_vec();
-
-    // println!("Hashed shared secret: {}", hex::encode(&hashed_secret));
 
     Ok(shared_secret)
 }


### PR DESCRIPTION
Performance optimized.

Release build:
6% faster
less than 60% CPU usage under load (10000 rewraps)

`ecdh_custom()` about 0.0063 ms faster (approximately 0.28% improvement).

Updated the Rust backend build process and removed superfluous code. The Github Actions workflow will now strip the release binary to reduce its size. The build settings for the Rust backend have been optimized in Cargo.toml and updated the version. In addition, unused code for hashing the shared point's x-coordinate in the main.rs file has been removed.